### PR TITLE
Add user warning regarding the use of a web service to create img diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ npx arkit -f src/main.js -o puml
 LEVEL=info npx arkit -e "node_modules,test,dist,coverage" -o puml
 ```
 
+:warning: Arkit is using a web service to convert PlantUML to SVG/PNG. 
+It's hosted at arkit.pro and does not store any data.
+**If you want to use Arkit at work make sure this is fine with your company tools policy**.
+
 If your project is huge and first diagrams look messy, it's better to generate them per feature, architectural layer, etc.
 
 Once you satisfied with results, add arkit command to your build script, so it will keep your architecture diagrams up-to-date.

--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ if (require.main === module) {
   console.log(`Running against ${config.directory} with the following config:`);
   console.log(JSON.stringify(config.final, undefined, 2));
 
+  console.log("\nDisclaimer : Arkit is using a web service to convert PlantUML to SVG/PNG.");
+  console.log("It's hosted at arkit.pro and does not store any data.");
+  console.log("If you want to use Arkit at work make sure this is fine with your company tools policy.\n");
+
   getOutputs(config).then(outputs => {
     outputs
       .sort((a, b) => {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "prettier": "1.18.2",
     "ts-jest": "24.0.2",
     "tslint": "5.19.0",
+    "typescript": "3.6.2",
     "typescript-json-schema": "0.40.0",
     "worldstar": "1.2.3"
   },

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -14,10 +14,10 @@ export class Converter {
   convert(pathOrType: string, puml: string): Promise<SavedString> {
     const fullExportPath = path.resolve(this.config.directory, pathOrType);
     const ext = path.extname(fullExportPath);
-    const shouldConvertAndSave = Object.values(OutputFormat).includes(
+    const shouldConvertAndSave = Object.values<any>(OutputFormat).includes(
       ext.replace(".", "")
     );
-    const shouldConvertAndOutput = Object.values(OutputFormat).includes(
+    const shouldConvertAndOutput = Object.values<any>(OutputFormat).includes(
       pathOrType
     );
 


### PR DESCRIPTION
**What's wrong** :
Arkit is currently using a web service to convert PlantUML to SVG/PNG, for user convenience.  
The user should be informed about it without having to read the source code.  

**Goal** :
The intent is to make sure that user don't get into trouble in professional setting while using a software violating their company policies.

**Proposal** :
Add a disclaimer in the readme and in the console output.  
I've considered prompting the user for confirmation before each web request but found it too annoying.
Another option will be to prompt the user only once by remembering his consent but it's a lot more work.

What do think about that ? Is the english fine ?

Best regards.

Augustin 🇫🇷 

PS : also fixed a type issue with the last Typescript version.