### PR TITLE
Checking if filenames match reserved JS words.

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -276,12 +276,14 @@ export class Generator {
     filename: string,
     componentConfig: ComponentSchema
   ): string {
+    const reservedNames = ['constructor', 'toString', 'valueOf'];
     const nameFormat = componentConfig.format;
 
     if (nameFormat === ComponentNameFormat.FULL_NAME) {
       return path.basename(filename);
     }
 
-    return path.basename(filename, path.extname(filename));
+    const componentName = path.basename(filename, path.extname(filename));
+    return reservedNames.indexOf(componentName) === -1 ? componentName : `_${componentName}`;
   }
 }


### PR DESCRIPTION
This is a (probably partial) fix for #28. It doesn't introduce any unit test failures, though seems like there's a bunch already happening. :grimacing: 